### PR TITLE
Implement :telemetry for algolia-elixir

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,13 +22,14 @@ defmodule Algolia.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :hackney]]
+    [applications: [:logger, :hackney, :telemetry]]
   end
 
   defp deps do
     [
       {:hackney, "~> 1.10"},
       {:jason, "~> 1.0"},
+      {:telemetry, "~> 1.0"},
       # Docs
       {:ex_doc, "~> 0.19", only: :dev},
       {:inch_ex, ">= 0.0.0", only: :dev}

--- a/mix.lock
+++ b/mix.lock
@@ -14,5 +14,6 @@
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+Application.ensure_all_started(:algolia)
 ExUnit.start()


### PR DESCRIPTION
This PR is the first part for https://github.com/slab/slab/issues/5766

This adds one event and one span (for a total of 4 possible 

- `[:algolia, :search, :result]` event includes the processing time and number of hits for a given search
- `[:algolia, :request]` span wraps the whole request, including retries

This will allow us to extract the following metrics later:

- Duration of the whole request (summary/distribution), that is, including retries if any
- Number of retries (distribution)
- Number of hits per search (distribution, with a 0 bucket to get "misses")
- Algolia's returned processingTimeMS (summary/distribution)