### PR TITLE
Fix browse URL

### DIFF
--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -37,7 +37,7 @@ defmodule Algolia.Paths do
     index(index) <> "/facets/" <> URI.encode(facet) <> "/query"
   end
 
-  def browse(index, opts), do: index(index) <> to_query(opts)
+  def browse(index, opts), do: index(index) <> "/browse" <> to_query(opts)
 
   def clear(index), do: index(index) <> "/clear"
 


### PR DESCRIPTION
Apparently I got this wrong in #4 and accidentally used the URL for the search endpoint instead of browse. The observable differences are pretty subtle, but search doesn't support paging all the way through the data and doesn't return a cursor.