### PR TITLE
Refactor to use Tesla middleware internally

### DIFF
--- a/lib/algolia/middleware/base_url.ex
+++ b/lib/algolia/middleware/base_url.ex
@@ -1,0 +1,26 @@
+defmodule Algolia.Middleware.BaseUrl do
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
+  def call(env, next, _opts) do
+    hint = env.opts[:subdomain_hint]
+    curr_retry = env.opts[:curr_retry]
+
+    host =
+      case {hint, curr_retry} do
+        {:read, 0} ->
+          "#{Algolia.application_id()}-dsn.algolia.net"
+
+        {:write, 0} ->
+          "#{Algolia.application_id()}.algolia.net"
+
+        {:insights, _} ->
+          "insights.algolia.io"
+
+        _ ->
+          "#{Algolia.application_id()}-#{curr_retry}.algolianet.com"
+      end
+
+    Tesla.run(%{env | url: "https://#{host}#{env.url}"}, next)
+  end
+end

--- a/lib/algolia/middleware/headers.ex
+++ b/lib/algolia/middleware/headers.ex
@@ -1,0 +1,13 @@
+defmodule Algolia.Middleware.Headers do
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
+  def call(env, next, _opts) do
+    env
+    |> Tesla.put_headers([
+      {"X-Algolia-API-Key", Algolia.api_key()},
+      {"X-Algolia-Application-Id", Algolia.application_id()}
+    ])
+    |> Tesla.run(next)
+  end
+end

--- a/lib/algolia/middleware/retry.ex
+++ b/lib/algolia/middleware/retry.ex
@@ -1,0 +1,22 @@
+defmodule Algolia.Middleware.Retry do
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
+  def call(env, next, _opts) do
+    curr_retry = 0
+
+    retry(env, next, curr_retry)
+  end
+
+  defp retry(_env, _next, 4) do
+    {:error, {"Unable to connect to Algolia", 4}}
+  end
+
+  defp retry(env, next, curr_retry) do
+    opts = Keyword.put(env.opts || [], :curr_retry, curr_retry)
+
+    with {:error, _} <- Tesla.run(%{env | opts: opts}, next) do
+      retry(env, next, curr_retry + 1)
+    end
+  end
+end

--- a/lib/algolia/middleware/telemetry.ex
+++ b/lib/algolia/middleware/telemetry.ex
@@ -1,0 +1,28 @@
+defmodule Algolia.Middleware.Telemetry do
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
+  def call(env, next, _opts) do
+    start_metadata = %{
+      request: %{method: env.method, path: env.url, opts: env.opts, headers: env.headers},
+      subdomain_hint: env.opts[:subdomain_hint]
+    }
+
+    :telemetry.span([:algolia, :request], start_metadata, fn ->
+      {result, stop_metadata} =
+        case Tesla.run(env, next) do
+          {:ok, %{status: code} = env} when code in 200..299 ->
+            {{:ok, env}, %{success: true, result: env.body, retries: env.opts[:curr_retry]}}
+
+          {:ok, %{status: code} = env} ->
+            {{:error, code, env.body},
+             %{success: false, error: env.body, retries: env.opts[:curr_retry]}}
+
+          {:error, {error, retries}} ->
+            {{:error, error}, %{success: false, error: error, retries: retries}}
+        end
+
+      {result, Map.merge(start_metadata, stop_metadata)}
+    end)
+  end
+end


### PR DESCRIPTION
This change takes several of the cross-cutting concerns around making requests and puts them in middleware:

- Emitting telemetry events
- Setting auth headers
- Retrying failed requests, using different subdomains
- Encoding/decoding JSON request/response bodies

This greatly simplifies `send_request` and makes all of things it does easier to reason about in isolation.