### PR TITLE
Use POST for search and browse

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -120,12 +120,16 @@ defmodule Algolia do
   def search(client, index, query, opts \\ []) do
     {req_opts, opts} = pop_request_opts(opts)
 
-    path = Paths.search(index, query, opts)
+    body =
+      opts
+      |> Map.new()
+      |> Map.put(:query, query)
 
     with {:ok, %{} = data} <-
            send_request(client, :read, %{
-             method: :get,
-             path: path,
+             method: :post,
+             path: Paths.search(index),
+             body: body,
              options: req_opts
            }) do
       :telemetry.execute(
@@ -207,10 +211,13 @@ defmodule Algolia do
   def browse(client, index, opts \\ []) do
     {req_opts, opts} = pop_request_opts(opts)
 
-    path = Paths.browse(index, opts)
-
     with {:ok, %{} = data} <-
-           send_request(client, :read, %{method: :get, path: path, options: req_opts}) do
+           send_request(client, :read, %{
+             method: :post,
+             path: Paths.browse(index),
+             body: Map.new(opts),
+             options: req_opts
+           }) do
       :telemetry.execute(
         [:algolia, :browse, :result],
         %{hits: data["nbHits"], processing_time: data["processingTimeMS"]},

--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -28,16 +28,13 @@ defmodule Algolia.Paths do
     object(index, object_id) <> "/partial" <> to_query(params)
   end
 
-  def search(index, query, opts) do
-    params = Keyword.put(opts, :query, query)
-    index(index) <> to_query(params)
-  end
+  def search(index), do: index(index) <> "/query"
 
   def search_facet(index, facet) do
     index(index) <> "/facets/" <> URI.encode(facet) <> "/query"
   end
 
-  def browse(index, opts), do: index(index) <> "/browse" <> to_query(opts)
+  def browse(index), do: index(index) <> "/browse"
 
   def clear(index), do: index(index) <> "/clear"
 


### PR DESCRIPTION
This is more consistent with what official Algolia clients do, and it avoids an issue with large options (like a large filters string, for instance) exceeding the maximum size allowed for a URI.