### PR TITLE
Add tests for middleware

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -57,7 +57,12 @@ defmodule Algolia do
     middleware_fn = Keyword.get(opts, :middleware, & &1)
     adapter = Keyword.get(opts, :adapter)
 
-    middleware = opts |> default_middleware() |> middleware_fn.()
+    middleware =
+      opts
+      |> Keyword.put_new_lazy(:api_key, &api_key/0)
+      |> Keyword.put_new_lazy(:application_id, &application_id/0)
+      |> default_middleware()
+      |> middleware_fn.()
 
     Tesla.client(middleware, adapter)
   end

--- a/lib/algolia/middleware/base_url.ex
+++ b/lib/algolia/middleware/base_url.ex
@@ -5,7 +5,7 @@ defmodule Algolia.Middleware.BaseUrl do
   def call(env, next, opts) do
     hint = env.opts[:subdomain_hint]
     curr_retry = env.opts[:curr_retry]
-    application_id = Keyword.get_lazy(opts, :application_id, &Algolia.application_id/0)
+    application_id = Keyword.fetch!(opts, :application_id)
 
     host =
       case {hint, curr_retry} do

--- a/lib/algolia/middleware/headers.ex
+++ b/lib/algolia/middleware/headers.ex
@@ -3,8 +3,8 @@ defmodule Algolia.Middleware.Headers do
 
   @impl Tesla.Middleware
   def call(env, next, opts) do
-    api_key = Keyword.get_lazy(opts, :api_key, &Algolia.api_key/0)
-    application_id = Keyword.get_lazy(opts, :application_id, &Algolia.application_id/0)
+    api_key = Keyword.fetch!(opts, :api_key)
+    application_id = Keyword.fetch!(opts, :application_id)
 
     env
     |> Tesla.put_headers([

--- a/test/algolia/middleware/base_url_test.exs
+++ b/test/algolia/middleware/base_url_test.exs
@@ -1,0 +1,99 @@
+defmodule Algolia.Middleware.BaseUrlTest do
+  use ExUnit.Case, async: true
+
+  alias Algolia.Middleware.BaseUrl
+
+  alias Tesla.Env
+
+  @opts [application_id: "application_id"]
+
+  describe "read requests" do
+    test "use dsn subdomain for first request" do
+      assert {:ok, env} =
+               BaseUrl.call(
+                 %Env{url: "/1/indexes", opts: [subdomain_hint: :read, curr_retry: 0]},
+                 [],
+                 @opts
+               )
+
+      assert env.url == "https://application_id-dsn.algolia.net/1/indexes"
+    end
+
+    test "use numbered subdomain for subsequent requests" do
+      assert {:ok, env} =
+               BaseUrl.call(
+                 %Env{url: "/1/indexes", opts: [subdomain_hint: :read, curr_retry: 1]},
+                 [],
+                 @opts
+               )
+
+      assert env.url == "https://application_id-1.algolianet.com/1/indexes"
+
+      assert {:ok, env} =
+               BaseUrl.call(
+                 %Env{url: "/1/indexes", opts: [subdomain_hint: :read, curr_retry: 3]},
+                 [],
+                 @opts
+               )
+
+      assert env.url == "https://application_id-3.algolianet.com/1/indexes"
+    end
+  end
+
+  describe "write requests" do
+    test "use basic subdomain for first request" do
+      assert {:ok, env} =
+               BaseUrl.call(
+                 %Env{url: "/1/indexes/foo/bar", opts: [subdomain_hint: :write, curr_retry: 0]},
+                 [],
+                 @opts
+               )
+
+      assert env.url == "https://application_id.algolia.net/1/indexes/foo/bar"
+    end
+
+    test "use numbered subdomain for subsequent requests" do
+      assert {:ok, env} =
+               BaseUrl.call(
+                 %Env{url: "/1/indexes/foo/bar", opts: [subdomain_hint: :write, curr_retry: 1]},
+                 [],
+                 @opts
+               )
+
+      assert env.url == "https://application_id-1.algolianet.com/1/indexes/foo/bar"
+
+      assert {:ok, env} =
+               BaseUrl.call(
+                 %Env{url: "/1/indexes/foo/bar", opts: [subdomain_hint: :write, curr_retry: 3]},
+                 [],
+                 @opts
+               )
+
+      assert env.url == "https://application_id-3.algolianet.com/1/indexes/foo/bar"
+    end
+  end
+
+  describe "insights requests" do
+    test "use insights host for first request" do
+      assert {:ok, env} =
+               BaseUrl.call(
+                 %Env{url: "/1/events", opts: [subdomain_hint: :insights, curr_retry: 0]},
+                 [],
+                 @opts
+               )
+
+      assert env.url == "https://insights.algolia.io/1/events"
+    end
+
+    test "use insights host for retried requests" do
+      assert {:ok, env} =
+               BaseUrl.call(
+                 %Env{url: "/1/events", opts: [subdomain_hint: :insights, curr_retry: 3]},
+                 [],
+                 @opts
+               )
+
+      assert env.url == "https://insights.algolia.io/1/events"
+    end
+  end
+end

--- a/test/algolia/middleware/headers_test.exs
+++ b/test/algolia/middleware/headers_test.exs
@@ -1,0 +1,42 @@
+defmodule Algolia.Middleware.HeadersTest do
+  use ExUnit.Case, async: true
+
+  alias Algolia.Middleware.Headers
+
+  alias Tesla.Env
+
+  test "with no headers to start" do
+    assert {:ok, env} = Headers.call(%Env{url: "/foo"}, [], api_key: "abc", application_id: "def")
+
+    assert env.headers == [
+             {"X-Algolia-API-Key", "abc"},
+             {"X-Algolia-Application-Id", "def"}
+           ]
+  end
+
+  test "adds to the headers that are already present" do
+    assert {:ok, env} =
+             Headers.call(%Env{url: "/foo", headers: [{"Content-Type", "application/json"}]}, [],
+               api_key: "abc",
+               application_id: "def"
+             )
+
+    assert env.headers == [
+             {"Content-Type", "application/json"},
+             {"X-Algolia-API-Key", "abc"},
+             {"X-Algolia-Application-Id", "def"}
+           ]
+  end
+
+  test "raises if :api_key is missing" do
+    assert_raise KeyError, fn ->
+      Headers.call(%Env{url: "/foo"}, [], application_id: "def")
+    end
+  end
+
+  test "raises if :application_id is missing" do
+    assert_raise KeyError, fn ->
+      Headers.call(%Env{url: "/foo"}, [], api_key: "abc")
+    end
+  end
+end

--- a/test/algolia/middleware/retry_test.exs
+++ b/test/algolia/middleware/retry_test.exs
@@ -1,0 +1,52 @@
+defmodule Algolia.Middleware.RetryTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    client =
+      Tesla.client(
+        [Algolia.Middleware.Retry],
+        Tesla.Mock
+      )
+
+    {:ok, client: client}
+  end
+
+  test "returns response with successful status code", %{client: client} do
+    Tesla.Mock.mock(fn
+      %{url: "/1/indexes", opts: [curr_retry: 0]} ->
+        {200, [], "OK"}
+    end)
+
+    assert {:ok, %{body: "OK"}} = Tesla.get(client, "/1/indexes")
+  end
+
+  test "returns response with unsuccessful status code", %{client: client} do
+    Tesla.Mock.mock(fn
+      %{url: "/1/indexes", opts: [curr_retry: 0]} ->
+        {500, [], "you did a bad job"}
+    end)
+
+    assert {:ok, %{body: "you did a bad job"}} = Tesla.get(client, "/1/indexes")
+  end
+
+  test "retries when request errors", %{client: client} do
+    Tesla.Mock.mock(fn
+      %{url: "/1/indexes", opts: [curr_retry: 3]} ->
+        {200, [], "OK"}
+
+      %{url: "/1/indexes"} ->
+        {:error, :econnrefused}
+    end)
+
+    assert {:ok, %{body: "OK", opts: [curr_retry: 3]}} = Tesla.get(client, "/1/indexes")
+  end
+
+  test "gives up after 4 attempts", %{client: client} do
+    Tesla.Mock.mock(fn
+      %{url: "/1/indexes", opts: [curr_retry: retry]} when retry <= 3 ->
+        {:error, :econnrefused}
+    end)
+
+    assert {:error, {"Unable to connect to Algolia", 4}} = Tesla.get(client, "/1/indexes")
+  end
+end


### PR DESCRIPTION
Add unit tests for:

- `Algolia.Middleware.BaseUrl`
- `Algolia.Middleware.Headers`
- `Algolia.Middleware.Retry`

The first two are tested by calling the middleware directly with a `Tesla.Env` struct. This is modeled after how similar middleware in Tesla is tested.

The retry middleware needs more setup because it needs to act based on the response to the request. So that test is using `Tesla.Mock` to set up expected responses.