### PR TITLE
Add more detail to API docs, and add client arg to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,26 @@ All responses are deserialized into maps before returning one of these responses
 
 ## Examples
 
+### Creating a client
+
+All API function that make requests require a client.
+
+```elixir
+client = Algolia.new()
+```
+
 ### Searching
 
 #### Searching an index
 
 ```elixir
-"my_index" |> Algolia.search("some query")
+Algolia.search(client, "my_index", "some query")
 ```
 
 With options:
 
 ```elixir
-"my_index" |> Algolia.search("some query", attributesToRetrieve: "firstname", hitsPerPage: 20)
+Algolia.search(client, "my_index", "some query", attributesToRetrieve: "firstname", hitsPerPage: 20)
 ```
 
 See all available search options [**here**](https://www.algolia.com/doc/rest#full-text-search-parameters).
@@ -61,16 +69,16 @@ See all available search options [**here**](https://www.algolia.com/doc/rest#ful
 Browsing is like search but skips most ranking and allows fetching more results at once.
 
 ```elixir
-"my_index" |> Algolia.browse("some query", filter: "color:red")
+Algolia.browse(client, "my_index", query: "some query", filter: "color:red")
 ```
 
 #### Multiple queries at once
 
 ```elixir
-Algolia.multi([
-    %{index_name => "my_index1", query: "search query"},
-    %{index_name => "my_index2", query: "another query", hitsPerPage: 3,},
-    %{index_name => "my_index3", query: "3rd query", tagFilters: "promotion"}])
+Algolia.multi(client, [
+  %{index_name: "my_index1", query: "search query"},
+  %{index_name: "my_index2", query: "another query", hitsPerPage: 3},
+  %{index_name: "my_index3", query: "3rd query", tagFilters: "promotion"}
 ])
 ```
 
@@ -80,7 +88,7 @@ You can specify a strategy to optimize your multiple queries:
 - `stop_if_enough_matches`: Execute the sequence of queries until the number of hits is reached by the sum of hits.
 
 ```elixir
-Algolia.multi([query1, query2], strategy: :stop_if_enough_matches)
+Algolia.multi(client, [query1, query2], strategy: :stop_if_enough_matches)
 ```
 
 ### Saving
@@ -91,19 +99,19 @@ Save a single object to index without specifying objectID. You must have `object
 inside object, or use the `id_attribute` option (see below).
 
 ```elixir
-"my_index" |> Algolia.save_object(%{objectID: "1"})
+Algolia.save_object(client, "my_index", %{objectID: "1"})
 ```
 
 Save a single object with a given objectID:
 
 ```elixir
-"my_index" |> Algolia.save_object(%{title: "hello"}, "12345")
+Algolia.save_object(client, "my_index", %{title: "hello"}, "12345")
 ```
 
 Save multiple objects to an index:
 
 ```elixir
-"my_index" |> Algolia.save_objects([%{objectID: "1"}, %{objectID: "2"}])
+Algolia.save_objects(client, "my_index", [%{objectID: "1"}, %{objectID: "2"}])
 ```
 
 ### Updating
@@ -111,23 +119,22 @@ Save multiple objects to an index:
 Partially update a single object:
 
 ```elixir
-"my_index" |> Algolia.partial_update_object(%{title: "hello"}, "12345")
+Algolia.partial_update_object(client, "my_index", %{title: "hello"}, "12345")
 ```
 
 Update multiple objects. You must have `objectID` in each object, or use the `id_attribute` option (see below).
 
 ```elixir
-"my_index" |> Algolia.partial_update_objects([%{objectID: "1"}, %{objectID: "2"}])
+Algolia.partial_update_objects(client, "my_index", [%{objectID: "1"}, %{objectID: "2"}])
 ```
 
 Partial update by default creates a new object if an object does not exist at the
 objectID. You can turn this off by passing `false` to the `:upsert?` option.
 
 ```elixir
-"my_index" |> Algolia.partial_update_object(%{title: "hello"}, "12345", upsert?: false)
-"my_index" |> Algolia.partial_update_objects([%{id: "1"}, %{id: "2"}], id_attribute: :id, upsert?: false)
+Algolia.partial_update_object(client, "my_index", %{title: "hello"}, "12345", upsert?: false)
+Algolia.partial_update_objects(client, "my_index", [%{id: "1"}, %{id: "2"}], id_attribute: :id, upsert?: false)
 ```
-
 
 ### `id_attribute` option
 
@@ -135,45 +142,48 @@ All write functions such as `save_object` and `partial_update_object` come with 
 you specify the `objectID` from an existing field in the object, so you do not have to generate it yourself.
 
 ```elixir
-"my_index" |> Algolia.save_object(%{id: "2"}, id_attribute: :id)
+Algolia.save_object(client, "my_index", %{id: "2"}, id_attribute: :id)
 ```
 
 It also works for batch operations, such as `save_objects` and `partial_update_objects`:
 
 ```elixir
-"my_index" |> Algolia.save_objects([%{id: "1"}, %{id: "2"}], id_attribute: :id)
+Algolia.save_objects(client, "my_index", [%{id: "1"}, %{id: "2"}], id_attribute: :id)
 ```
-
 
 ### Wait for task
 
 All write operations can be waited on by simply piping the response into `wait/1`:
 
 ```elixir
-"my_index" |> Algolia.save_object(%{id: "123"}) |> Algolia.wait()
+client
+|> Algolia.save_object("my_index", %{id: "123"})
+|> Algolia.wait(client)
 ```
 
 The client polls the server to check the status of the task.
 You can specify a time (in milliseconds) between each tick of the poll; the default is 1000ms (1 second).
 
 ```elixir
-"my_index" |> Algolia.save_object(%{id: "123"}) |> Algolia.wait(2_000)
+client
+|> Algolia.save_object("my_index", %{id: "123"})
+|> Algolia.wait(client, retry_delay: 2_000)
 ```
 
-You can also explicitly pass a `taskID` to `wait`:
+You can also explicitly pass a `taskID` to `wait_task`:
 
 
 ```elixir
 {:ok, %{"taskID" => task_id, "indexName" => index}}
-  = "my_index" |> Algolia.save_object(%{id: "123"})
+  = Algolia.save_object(client, "my_index", %{id: "123"})
 
-Algolia.wait(index, task_id)
+Algolia.wait_task(client, index, task_id)
 ```
 
 Optionally including the poll interval:
 
 ```elixir
-Algolia.wait(index, task_id, 2_000)
+Algolia.wait(client, index, task_id, retry_delay: 2_000)
 ```
 
 ### Index related operations
@@ -181,25 +191,25 @@ Algolia.wait(index, task_id, 2_000)
 #### Listing all indexes
 
 ```elixir
-Algolia.list_indexes()
+Algolia.list_indexes(client)
 ```
 
 #### Move an index
 
 ```elixir
-Algolia.move_index(source_index, destination_index)
+Algolia.move_index(client, source_index, destination_index)
 ```
 
 #### Copy an index
 
 ```elixir
-Algolia.copy_index(source_index, destination_index)
+Algolia.copy_index(client, source_index, destination_index)
 ```
 
 #### Clear an index
 
 ```elixir
-Algolia.clear_index(index)
+Algolia.clear_index(client, index)
 ```
 
 ### Settings
@@ -207,7 +217,7 @@ Algolia.clear_index(index)
 #### Get index settings
 
 ```elixir
-Algolia.get_settings(index)
+Algolia.get_settings(client, index)
 ```
 
 Example response:
@@ -238,7 +248,7 @@ Example response:
 #### Update index settings
 
 ```elixir
-Algolia.set_settings(index, %{"hitsPerPage" => 20})
+Algolia.set_settings(client, index, %{"hitsPerPage" => 20})
 
 > {:ok, %{"updatedAt" => "2013-08-21T13:20:18.960Z",
           "taskID" => 10210332.
@@ -250,7 +260,7 @@ Algolia.set_settings(index, %{"hitsPerPage" => 20})
 #### Push events
 
 ```elixir
-Algolia.push_events([
+Algolia.push_events(client, [
   %{
     "eventType" => "click",
     "eventName" => "Product Clicked",

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -1,6 +1,9 @@
 defmodule Algolia do
   @moduledoc """
-  Elixir implementation of Algolia search API
+  Elixir implementation of Algolia Search API.
+
+  You can interact with Algolia's API by creating a new client using `new/1`, and then using
+  the other functions in this modules to make requests with that client.
   """
 
   alias Algolia.Paths
@@ -29,23 +32,74 @@ defmodule Algolia do
     defexception message: "The ObjectID cannot be an empty string"
   end
 
+  @doc false
   def application_id do
     System.get_env("ALGOLIA_APPLICATION_ID") || Application.get_env(:algolia, :application_id) ||
       raise MissingApplicationIDError
   end
 
+  @doc false
   def api_key do
     System.get_env("ALGOLIA_API_KEY") || Application.get_env(:algolia, :api_key) ||
       raise MissingAPIKeyError
   end
 
+  @typedoc """
+  A client to use to communicate with Algolia.
+
+  All API functions require a client to be able to make requests.
+  """
   @type client() :: Tesla.Client.t()
+
+  @typedoc """
+  The name of an Algolia index.
+  """
   @type index() :: String.t()
+
+  @typedoc """
+  Generic options that can be passed to any API function.
+  """
   @type request_option() :: {:headers, Tesla.Env.headers()}
   @type result(resp) :: {:ok, resp} | {:error, any()}
 
   @doc """
-  Create a new Algolia client.
+  Creates a new Algolia client.
+
+  A client must be passed to any function that makes a request to Algolia.
+
+  ## Examples
+
+      client = Algolia.new(
+        api_key: "my_api_key",
+        application_id: "my_application_id"
+      )
+      Algolia.search(client, "my_index", "some query")
+
+      # adding logging middleware
+      client = Algolia.new(
+        middleware: fn middleware ->
+          middleware ++ [
+            {Tesla.Middleware.Logger, filter_headers: ["X-Algolia-API-Key"]}
+          ]
+        end
+      )
+
+      # set a custom adapter
+      client = Algolia.new(adapter: Tesla.Adapter.Mint)
+
+  ## Options
+
+  * `:api_key` - the API key to use for Algolia. If unset, reads from the `ALGOLIA_API_KEY`
+    environment variable or the `:api_key` key in the `:algolia` application config.
+  * `:application_id` - the application ID to use for Algolia. If unset, reads from the
+    `ALGOLIA_APPLICATION_ID` environment variable or the `:application_id` key in the
+    `:algolia` application config.
+  * `:middleware` - a function that can be used to alter the default list of Tesla middleware
+    that will be used. The function takes the default list of middleware as an argument, so
+    you can inject middleware as needed. Note that removing any of the default middleware
+    might break the client.
+  * `:adapter` - the Tesla HTTP adapter to use. Defaults to Tesla's default adapter, which
+    is `:httpc` by default but can be overridden in the `:tesla` application config.
   """
   @spec new([
           {:api_key, String.t()}
@@ -80,7 +134,26 @@ defmodule Algolia do
   @type multi_strategy() :: nil | :stop_if_enough_matches
 
   @doc """
-  Multiple queries
+  Performs multiple search queries in a single request.
+
+  Each entry in `queries` should be a map with `:index_name` indicating which index to search,
+  and the remaining keys corresponding to [Algolia search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/).
+
+  ## Examples
+
+      Algolia.multi(client, [
+        %{index_name: "my_index1", query: "search query"},
+        %{index_name: "my_index2", query: "another query", hitsPerPage: 3},
+        %{index_name: "my_index3", query: "3rd query", tagFilters: "promotion"}
+      ])
+
+  ## Options
+
+  * `:strategy` - strategy to use to decide whether to continue with additional queries. Can be
+    either `:none` or `:stop_if_enough_matches`. Defaults to `:none`. See
+    [Algolia's documentation](https://www.algolia.com/doc/rest-api/search/#search-multiple-indices)
+    for more information about the difference between these two strategies.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec multi(client(), [map()], [{:strategy, multi_strategy()} | request_option()]) ::
           result(map())
@@ -118,7 +191,27 @@ defmodule Algolia do
   end
 
   @doc """
-  Search a single index
+  Searches a single index.
+
+  ## Examples
+
+      # basic search
+      Algolia.search(client, "my_index", "some query")
+
+      # with search parameters
+      Algolia.search(client, "my_index", "some query",
+        attributesToRetrieve: "firstname",
+        hitsPerPage: 20
+      )
+
+  ## Options
+
+  Any of Algolia's supported [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/)
+  can be passed as options.
+
+  ### Additional options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec search(client(), index(), String.t(), [{atom(), any()} | request_option()]) ::
           result(map())
@@ -148,10 +241,10 @@ defmodule Algolia do
   end
 
   @doc """
-  Search for facet values
+  Searches for facet values.
 
   Enables you to search through the values of a facet attribute, selecting
-  only a **subset of those values that meet a given criteria**.
+  only a subset of those values that meet a given criteria.
 
   For a facet attribute to be searchable, it must have been declared in the
   `attributesForFaceting` index setting with the `searchable` modifier.
@@ -159,20 +252,12 @@ defmodule Algolia do
   Facet-searching only affects facet values. It does not impact the underlying
   index search.
 
-  The results are **sorted by decreasing count**. This can be adjusted via
-  `sortFacetValuesBy`.
-
-  By default, maximum **10 results are returned**. This can be adjusted via
-  `maxFacetHits`.
-
   ## Examples
 
       iex> Algolia.search_for_facet_values("species", "phylum", "dophyta")
-      {
-        :ok,
-        %{
-          "exhaustiveFacetsCount" => false,
-          "faceHits" => [
+      {:ok,
+        %{"exhaustiveFacetsCount" => false,
+          "facetHits" => [
             %{
               "count" => 9000,
               "highlighted" => "Pteri<em>dophyta</em>",
@@ -189,9 +274,19 @@ defmodule Algolia do
               "value" => "Cycadophyta"
             }
           ],
-          "processingTimeMS" => 42
-        }
-      }
+          "processingTimeMS" => 42}}
+
+  ## Options
+
+  Many of Algolia's supported [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/)
+  can be passed as options to filter the objects that are matched.
+
+  ### Additional options
+
+  * `:sortFacetValuesBy` - control how facets are sorted. Either `"count"` (by count, descending)
+    or `"alpha"` (by value alphabetically, ascending). Defaults to `"count"`.
+  * `:maxFacetHits` - maximum number of hits to return. Defaults to 10. Cannot exceed 100.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec search_for_facet_values(client(), index(), String.t(), String.t(), [
           request_option() | {atom(), any()}
@@ -210,9 +305,25 @@ defmodule Algolia do
   end
 
   @doc """
-  Browse a single index
+  Browses a single index.
+
+  Browsing is similar to searching, but it skips ranking results and allows fetching more
+  objects.
+
+  ## Example
+
+      Algolia.browse(client, "my_index", filters: "color:red AND kind:fruit")
+
+  ## Options
+
+  Any of Algolia's supported [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/)
+  can be passed as options, with the exception of `:distinct` which is not supported when browsing.
+
+  ### Additional options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
-  @spec browse(client(), index(), [request_option()]) :: result(map())
+  @spec browse(client(), index(), [request_option() | {atom(), any()}]) :: result(map())
   def browse(client, index, opts \\ []) do
     {req_opts, opts} = pop_request_opts(opts)
 
@@ -234,7 +345,15 @@ defmodule Algolia do
   end
 
   @doc """
-  Get an object in an index by objectID
+  Retrieves a single object from an index by ID.
+
+  ## Example
+
+      Algolia.get_object(client, "my_index", "123")
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec get_object(client(), index(), String.t(), [request_option()]) :: result(map())
   def get_object(client, index, object_id, opts \\ []) do
@@ -246,9 +365,44 @@ defmodule Algolia do
   end
 
   @doc """
-  Add an Object
+  Adds an object to an index, or replaces an existing one.
 
-  An attribute can be chosen as the objectID.
+  If the object does not have an `:objectID` or `"objectID"` key, then Algolia
+  will automatically generate one and add it to the object.
+
+  The `:id_attribute` option can be used to set the `:objectID` key based on an
+  existing key already on the object.
+
+  ## Examples
+
+      # add an object with automatically generated object ID
+      Algolia.add_object(client, "my_index", %{
+        kind: "fruit",
+        color: "red",
+        name: "apple"
+      })
+
+      # add or replace an object based on the object ID
+      Algolia.add_object(client, "my_index", %{
+        objectID: "123",
+        kind: "fruit",
+        color: "red",
+        name: "apple"
+      })
+
+      # set the object ID based on another attribute
+      Algolia.add_object(client, "my_index", %{
+        kind: "fruit",
+        color: "red",
+        name: "apple"
+      }, id_attribute: :name)
+      # resulting objectID is "apple"
+
+  ## Options
+
+  * `:id_attribute` - key to use as the `:objectID` of the object. If set, the
+    saved object will have both `:objectID` and this key set to the same value.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec add_object(client(), index(), map(), [
           {:id_attribute, atom() | String.t()} | request_option()
@@ -271,9 +425,42 @@ defmodule Algolia do
   end
 
   @doc """
-  Add multiple objects
+  Adds or replaces multiple objects in an index.
 
-  An attribute can be chosen as the objectID.
+  If any objects do not have an `:objectID` or `"objectID"` key, then Algolia
+  will automatically generate one and add it to the object.
+
+  The `:id_attribute` option can be used to set the `:objectID` key based on an
+  existing key already on the object.
+
+  ## Examples
+
+      # with automatically assigned object IDs
+      Algolia.add_objects(client, "my_index", [
+        %{name: "apple"},
+        %{name: "banana"},
+        %{name: "pear"}
+      ])
+
+      # adding or replacing objects based on object ID
+      Algolia.add_objects(client, "my_index", [
+        %{objectID: "fruit1", name: "apple"},
+        %{objectID: "fruit2", name: "banana"},
+        %{objectID: "fruit3", name: "pear"}
+      ])
+
+      # use the `:name` as the object IDs
+      Algolia.add_objects(client, "my_index", [
+        %{name: "apple"},
+        %{name: "banana"},
+        %{name: "pear"}
+      ], id_attribute: :name)
+
+  ## Options
+
+  * `:id_attribute` - key to use as the `:objectID` of the objects. If set, the
+    saved objects will have both `:objectID` and this key set to the same value.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec add_objects(client(), index(), [map()], [
           {:id_attribute, atom() | String.t()} | request_option()
@@ -289,8 +476,41 @@ defmodule Algolia do
   end
 
   @doc """
-  Save a single object, without objectID specified, must have objectID as
-  a field
+  Saves a single object, replacing it if it already exists.
+
+  Unlike `add_object/4`, the object must already have an object ID. The `:id_attribute`
+  option can still be used to set an object ID based on another attribute.
+
+  ## Examples
+
+      # add or replace an object based on the object ID
+      Algolia.save_object(client, "my_index", %{
+        objectID: "123",
+        kind: "fruit",
+        color: "red",
+        name: "apple"
+      })
+
+      # pass the object ID as its own argument
+      Algolia.save_object(client, "my_index", %{
+        kind: "fruit",
+        color: "red",
+        name: "apple"
+      }, "123")
+
+      # set the object ID based on another attribute
+      Algolia.save_object(client, "my_index", %{
+        kind: "fruit",
+        color: "red",
+        name: "apple"
+      }, id_attribute: :name)
+      # resulting objectID is "apple"
+
+  ## Options
+
+  * `:id_attribute` - key to use as the `:objectID` of the object. If set, the
+    saved object will have both `:objectID` and this key set to the same value.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec save_object(client(), index(), map(), [
           {:id_attribute, atom() | String.t()} | request_option()
@@ -328,7 +548,28 @@ defmodule Algolia do
   end
 
   @doc """
-  Save multiple objects
+  Saves multiple objects, replacing any that already exist.
+
+  Unlike `add_objects/4`, the objects must already have object IDs. The `:id_attribute`
+  option can still be used to set the object IDs based on another attribute.
+
+  ## Examples
+
+      Algolia.save_objects(client, "my_index", [
+        %{objectID: "1", name: "apple"},
+        %{objectID: "2", name: "orange"}
+      ])
+
+      # use `:id` for the object ID
+      Algolia.save_objects(client, "my_index", [
+        %{id: "1", name: "apple"},
+        %{id: "2", name: "orange"}
+      ], id_attribute: :id)
+
+  ## Options
+
+  * `:id_attribute` - key to use as the `:objectID` of the objects.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec save_objects(client(), index(), [map()], [
           {:id_attribute, atom() | String.t()} | request_option()
@@ -344,7 +585,25 @@ defmodule Algolia do
   end
 
   @doc """
-  Partially updates an object, takes option upsert: true or false
+  Partially updates a single object.
+
+  ## Examples
+
+      Algolia.partial_update_object(client, "my_index", %{
+        objectID: "1",
+        name: "apple"
+      })
+
+      # don't create the object if it doesn't already exist
+      Algolia.partial_update_object(client, "my_index", %{
+        id: "1",
+        name: "apple"
+      }, upsert?: false)
+
+  ## Options
+
+  * `:upsert?` - whether to create the record if it doesn't already exist. Defaults to `true`.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec partial_update_object(client(), index(), map(), String.t(), [
           {:upsert?, boolean()} | request_option()
@@ -358,7 +617,27 @@ defmodule Algolia do
   end
 
   @doc """
-  Partially updates multiple objects
+  Partially updates multiple objects.
+
+  ## Examples
+
+      Algolia.partial_update_objects(client, "my_index", [
+        %{objectID: "1", name: "apple"},
+        %{objectID: "2", name: "orange"}
+      ])
+
+      # don't create objects if they don't already exist,
+      # and use `:id` for the object ID
+      Algolia.partial_update_objects(client, "my_index", [
+        %{id: "1", name: "apple"},
+        %{id: "2", name: "orange"}
+      ], upsert?: false, id_attribute: :id)
+
+  ## Options
+
+  * `:upsert?` - whether to create any records that don't already exist. Defaults to `true`.
+  * `:id_attribute` - key to use as the `:objectID` of the objects.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec partial_update_objects(client(), index(), [map()], [
           {:upsert?, boolean()}
@@ -435,7 +714,11 @@ defmodule Algolia do
   end
 
   @doc """
-  Delete a object by its objectID
+  Deletes a single object by its object ID.
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec delete_object(client(), index(), String.t(), [request_option()]) :: result(map())
   def delete_object(client, index, object_id, opts \\ [])
@@ -453,7 +736,11 @@ defmodule Algolia do
   end
 
   @doc """
-  Delete multiple objects
+  Deletes multiple objects by object ID.
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec delete_objects(client(), index(), [String.t()], [request_option()]) :: result(map())
   def delete_objects(client, index, object_ids, opts \\ []) do
@@ -464,7 +751,17 @@ defmodule Algolia do
   end
 
   @doc """
-  Remove all objects matching a filter (including geo filters).
+  Removes all objects matching a filter.
+
+  ## Examples
+
+      iex> Algolia.delete_by(client, "index", filters: ["score < 30"])
+      {:ok,
+        %{"indexName" => "index",
+          "taskId" => 42,
+          "deletedAt" => "2018-10-30T15:33:13.556Z"}}
+
+  ## Options
 
   Allowed filter parameters:
 
@@ -475,10 +772,12 @@ defmodule Algolia do
   * `insideBoundingBox`
   * `insidePolygon`
 
-  ## Examples
+  They have the same meaning as when used for a query (such as with `search/4` or `browse/3`).
+  At least one type of filter is required.
 
-      iex> Algolia.delete_by("index", filters: ["score < 30"])
-      {:ok, %{"indexName" => "index", "taskId" => 42, "deletedAt" => "2018-10-30T15:33:13.556Z"}}
+  ### Additional options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec delete_by(client(), index(), [{atom(), any()} | request_option()]) :: result(map())
   def delete_by(client, index, opts) when is_list(opts) do
@@ -513,7 +812,11 @@ defmodule Algolia do
   defp validate_delete_by_opts!(opts), do: opts
 
   @doc """
-  List all indexes
+  Lists all indexes.
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec list_indexes(client(), [request_option()]) :: result(map())
   def list_indexes(client, opts \\ []) do
@@ -521,7 +824,11 @@ defmodule Algolia do
   end
 
   @doc """
-  Deletes the index
+  Deletes an index.
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec delete_index(client(), index(), [request_option()]) :: result(map())
   def delete_index(client, index, opts \\ []) do
@@ -531,7 +838,11 @@ defmodule Algolia do
   end
 
   @doc """
-  Clears all content of an index
+  Clears all objects from an index.
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec clear_index(client(), index(), [request_option()]) :: result(map())
   def clear_index(client, index, opts \\ []) do
@@ -541,7 +852,19 @@ defmodule Algolia do
   end
 
   @doc """
-  Set the settings of a index
+  Sets the settings of a index.
+
+  ## Example
+
+      iex> Algolia.set_settings(client, "my_index", %{hitsPerPage: 20})
+      {:ok,
+        %{"updatedAt" => "2013-08-21T13:20:18.960Z",
+          "taskID" => 10210332.
+          "indexName" => "my_index"}}
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec set_settings(client(), index(), map(), [request_option()]) :: result(map())
   def set_settings(client, index, settings, opts \\ []) do
@@ -553,7 +876,35 @@ defmodule Algolia do
   end
 
   @doc """
-  Get the settings of a index
+  Gets the settings of a index.
+
+  ## Example
+
+      iex> Algolia.get_settings(client, "my_index")
+      {:ok,
+        %{"minWordSizefor1Typo" => 4,
+          "minWordSizefor2Typos" => 8,
+          "hitsPerPage" => 20,
+          "attributesToIndex" => nil,
+          "attributesToRetrieve" => nil,
+          "attributesToSnippet" => nil,
+          "attributesToHighlight" => nil,
+          "ranking" => [
+              "typo",
+              "geo",
+              "words",
+              "proximity",
+              "attribute",
+              "exact",
+              "custom"
+          ],
+          "customRanking" => nil,
+          "separatorsToIndex" => "",
+          "queryType" => "prefixAll"}}
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec get_settings(client(), index(), [request_option()]) :: result(map())
   def get_settings(client, index, opts \\ []) do
@@ -563,7 +914,11 @@ defmodule Algolia do
   end
 
   @doc """
-  Moves an index to new one
+  Moves an index to new one.
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec move_index(client(), index(), index(), [request_option()]) :: result(map())
   def move_index(client, src_index, dst_index, opts \\ []) do
@@ -580,7 +935,11 @@ defmodule Algolia do
   end
 
   @doc """
-  Copies an index to a new one
+  Copies an index to a new one.
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec copy_index(client(), index(), index(), [request_option()]) :: result(map())
   def copy_index(client, src_index, dst_index, opts \\ []) do
@@ -597,19 +956,18 @@ defmodule Algolia do
   end
 
   @doc """
-  Get the logs of the latest search and indexing operations.
+  Gets the logs of the latest search and indexing operations.
 
   ## Options
 
-    * `:indexName` - Index for which log entries should be retrieved. When omitted,
-      log entries are retrieved across all indices.
-
-    * `:length` - Maximum number of entries to retrieve. Maximum allowed value: 1000.
-
-    * `:offset` - First entry to retrieve (zero-based). Log entries are sorted by
-      decreasing date, therefore 0 designates the most recent log entry.
-
-    * `:type` - Type of log to retrieve: `all` (default), `query`, `build` or `error`.
+  * `:indexName` - index for which log entries should be retrieved. When omitted,
+    log entries are retrieved across all indices.
+  * `:length` - maximum number of entries to retrieve. Maximum allowed value: 1000.
+  * `:offset` - first entry to retrieve (zero-based). Log entries are sorted by
+    decreasing date, therefore 0 designates the most recent log entry.
+  * `:type` - type of log to retrieve: `:all`, `:query`, `:build` or `:error`. Defaults
+    to `:all`.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec get_logs(client(), [
           {:indexName, index()}
@@ -624,8 +982,24 @@ defmodule Algolia do
   end
 
   @doc """
-  Wait for a task for an index to complete
-  returns :ok when it's done
+  Waits for a task for an index to complete.
+
+  Returns `:ok` when the task is completed.
+
+  ## Example
+
+      {:ok, %{"taskID" => task_id, "indexName" => index}} =
+        Algolia.save_object(client, %{id: "123"}, id_attribute: :id)
+
+      Algolia.wait_task(client, index, task_id)
+
+  See `wait/3` for a convenient shortcut using piping.
+
+  ## Options
+
+  * `:retry_delay` - number of milliseconds to wait before each request to Algolia to
+    check for task completion. Defaults to `1_000`, or one second.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec wait_task(client(), index(), String.t(), [
           {:retry_delay, integer()} | request_option()
@@ -651,8 +1025,30 @@ defmodule Algolia do
   end
 
   @doc """
-  Convinient version of wait_task/4, accepts a response to be waited on
-  directly. This enables piping a operation directly into wait_task
+  Waits on the task created by a previous request.
+
+  This is a convenient variation of `wait_task/4` that accepts a response from another
+  API function. You can pipe another API function into `wait/3` to only return the
+  response once the task is completed.
+
+  ## Examples
+
+      client
+      |> Algolia.save_object("my_index", %{id: "123"}, id_attribute: :id)
+      |> Algolia.wait(client)
+
+      client
+      |> Algolia.save_objects("my_index", [
+        %{id: "123"},
+        %{id: "234"}
+      ], id_attribute: :id)
+      |> Algolia.wait(client, retry_delay: 2_000)
+
+  ## Options
+
+  * `:retry_delay` - number of milliseconds to wait before each request to Algolia to
+    check for task completion. Defaults to `1_000`, or one second.
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec wait(result(map()), client(), [
           {:retry_delay, integer()} | request_option()
@@ -666,9 +1062,28 @@ defmodule Algolia do
   def wait(response, _client, _opts), do: response
 
   @doc """
-  Push events to the Insights REST API.
-  Corresponds to https://www.algolia.com/doc/rest-api/insights/#push-events
-  `events` should be a List of Maps, each Map having the fields described in the link above
+  Pushes events to the Insights API.
+
+  See Algolia's documentation for the [send events endpoint](https://www.algolia.com/doc/rest-api/insights/#send-events)
+  for more information on the fields that events should include.
+
+  ## Examples
+
+      Algolia.push_events(client, [
+        %{
+          "eventType" => "click",
+          "eventName" => "Product Clicked",
+          "index" => "products",
+          "userToken" => "user-123456",
+          "objectIDs" => ["9780545139700", "9780439784542"],
+          "queryID" => "43b15df305339e827f0ac0bdc5ebcaa7",
+          "positions" => [7, 6]
+        }
+      ])
+
+  ## Options
+
+  * `:headers` - list of additional HTTP headers to include in the request.
   """
   @spec push_events(client(), [map()], [request_option()]) :: result(map())
   def push_events(client, events, opts \\ []) do


### PR DESCRIPTION
This is probably the last thing I want to do here before we release the first version of our package.

My goals with the API docs were:

- Use consistent verb tense in the summaries for functions
- Document all supported keyword options, delegating (and linking) to Algolia's documentation in the case of search parameters, since there's too many for us to reasonably keep accurately documented.
- Include at least one example for most functions. A few functions seemed trivial enough that there wouldn't be much to show.