### PR TITLE
fix: typespec of result

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -60,7 +60,7 @@ defmodule Algolia do
   Generic options that can be passed to any API function.
   """
   @type request_option() :: {:headers, Tesla.Env.headers()}
-  @type result(resp) :: {:ok, resp} | {:error, any()}
+  @type result(resp) :: {:ok, resp} | {:error, any()} | {:error, pos_integer(), any()}
 
   @doc """
   Creates a new Algolia client.


### PR DESCRIPTION
## Context

We had an issue today because we forgot to pattern match on `{:error, code, body}`

```
%CaseClauseError{
  term: {:error, 400, %{
    "message" => "filters: Unexpected token string(Card) expected ‘)’ at col 22", "status" => 400
  }}
}
```

This also matches: https://github.com/slab/algolia-elixir/blob/3dcfa2c08afa9baa99ba562a889f32b0a43a1758/README.md?plain=1#L35


I fixed the issue, but

```
file.ex:107:pattern_match
The pattern can never match the type.

Pattern:
{:error, __status, _body}

Type:
{:error, _}
```